### PR TITLE
Make sure nil elements don't go into the widget

### DIFF
--- a/lib/event_list.rb
+++ b/lib/event_list.rb
@@ -15,7 +15,7 @@ class EventList
       end
     end
 
-    { items: event_list }
+    { items: event_list.compact }
 
   end
   

--- a/lib/lecture_list.rb
+++ b/lib/lecture_list.rb
@@ -23,7 +23,7 @@ class LectureList
       end
     end
     
-    { items: lecture_list }
+    { items: lecture_list.compact }
 
   end
   


### PR DESCRIPTION
Because we were using `map` against the parsed json, things that didn't meet the criteria were going into the output as nil, so we were getting blank stuff on the dashboard. Easily fixed with a bit of `compact` magic though.
