### PR TITLE
Re-add the old 2013 bookings metric

### DIFF
--- a/jobs/company_dashboard.rb
+++ b/jobs/company_dashboard.rb
@@ -12,7 +12,7 @@ SCHEDULER.every '1h', :first_in => 0 do
   send_event '2013-Value',    current: CompanyDashboard.value(2013),   prefix: "£"
   send_event '2013-ODCs',     current: CompanyDashboard.odcs(2013),    link: "https://certificates.theodi.org/status"
   send_event '2013-KPIs',     current: CompanyDashboard.kpis(2013),    suffix: "%"
-  #send_event '2013-Bookings', current: CompanyDashboard.bookings(2013), prefix: "£"
+  send_event '2013-Bookings', current: CompanyDashboard.old_bookings(2013), prefix: "£" # derprecated metric
   # Trello gubbins
   progress = CompanyDashboard.progress(2013)
   send_event '2013-q1-progress', min: 0, max: 100, value: progress[:q1]

--- a/lib/company_dashboard.rb
+++ b/lib/company_dashboard.rb
@@ -63,6 +63,10 @@ class CompanyDashboard < MetricsHelper
     select_metric 'burn', year
   end
   
+  def self.old_bookings(year = nil)
+    select_metric 'bookings', year
+  end
+  
   def self.commercial_bookings(year = nil)
     bookings(:commercial, year)
   end


### PR DESCRIPTION
This brings back the 2013 bookings metric, using the old current-year-bookings metric in the API. Should be fine to merge, but be aware it will knock out the data for an hour as we haven't resolved that 'first run' issue yet.
