### PR TITLE
Disable github PR stats

### DIFF
--- a/lib/github_stats.rb
+++ b/lib/github_stats.rb
@@ -34,7 +34,7 @@ class GithubDashboard
     merged_pulls = 0
     
     # ALL THIS CODE IS COMMENTED BECAUSE IT'S JUST TOO MEMORY-INTENSIVE.
-    # WE NEED A BETTER WAY
+    # WE NEED A BETTER WAY. SEE #106
     
     # github.repos.list(user: ENV['GITHUB_ORGANISATION'], :auto_pagination => true) do |repo|
     #   if repo.fork

--- a/spec/libs/github_stats_spec.rb
+++ b/spec/libs/github_stats_spec.rb
@@ -28,13 +28,15 @@ describe GithubDashboard do
         @result = GithubDashboard.externalpulls
       end
     end
+
+    # EXTERNAL PRS ARE DISABLED CURRENTLY. SEE #106
     
     it "should return the correct number of total external pull requests", :vcr do
-      @result[:total_pulls].should == 43
+      @result[:total_pulls].should == 0 #43
     end
     
     it "should return the correct number of merged external pull requests", :vcr do
-      @result[:merged_pulls].should == 24
+      @result[:merged_pulls].should == 0 #24
     end
     
   end


### PR DESCRIPTION
Too memory-intensive, we need a better way. Resolves #106, I hope.
