### PR TITLE
Allow dashboards to be framed

### DIFF
--- a/dashboards.rb
+++ b/dashboards.rb
@@ -15,6 +15,7 @@ end
 configure do
   set :auth_token, 'YOUR_AUTH_TOKEN'
   set :default_dashboard, 'company'
+  set :protection, except: :frame_options
 
   set :partial_template_engine, :erb
   enable :partial_underscores


### PR DESCRIPTION
Request from @langphil

I've set `X-Frame-Options` to allow any site to frame dashboards. This could be dangerous for some sites, but as we're not accepting user data or anything, we should be fine. There's no current cross-browser way to support whitelisting or anything else.