### PR TITLE
Show new network members rather than cumulative

### DIFF
--- a/dashboards/company/2015.erb
+++ b/dashboards/company/2015.erb
@@ -1,6 +1,6 @@
 <ul class="grid rows-2 cols-4" id="company">
   <li class="row-1 col-1">
-    <div data-id="Lifetime-network-size" data-view="Number" data-unordered="true" data-title="<%= t 'company.network' %>" id="network-size" data-tooltip="<%= t 'company.2015.tips.network' %>"></div>
+    <div data-id="2015-network-size" data-view="Number" data-unordered="true" data-title="<%= t 'company.network' %>" id="network-size" data-tooltip="<%= t 'company.2015.tips.network' %>"></div>
   </li>
   <li class="row-1 col-2">
     <div data-id="2015-people-trained" data-view="NumberWithTarget" data-unordered="true" data-title="<%= t 'company.training' %>" id="people-trained" data-tooltip="<%= t 'company.2015.tips.training' %>"></div>

--- a/jobs/company_dashboard.rb
+++ b/jobs/company_dashboard.rb
@@ -79,6 +79,7 @@ end
 
 SCHEDULER.every '1h', :first_in => Time.now + 10 do
   # 2015 Company
+  send_event               '2015-network-size', current: CompanyDashboard.network_size(2015)['actual']
   send_metric_with_targets '2015-people-trained', CompanyDashboard.people_trained(2015)
   send_metric_with_targets '2015-trainers-trained', CompanyDashboard.trainers_trained(2015)
   send_metric_with_targets '2015-Reach', CompanyDashboard.reach(2015)

--- a/spec/cassettes/CompanyDashboard/should_get_network_size.yml
+++ b/spec/cassettes/CompanyDashboard/should_get_network_size.yml
@@ -19,7 +19,7 @@ http_interactions:
       content-type:
       - application/json;charset=utf-8
       date:
-      - Tue, 02 Jun 2015 12:21:54 GMT
+      - Fri, 05 Jun 2015 12:25:42 GMT
       x-content-type-options:
       - nosniff
       connection:
@@ -30,7 +30,38 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"_id":"54b68eaeef922c5d1001d778","name":"current-year-network-size","time":"2014-12-31T23:59:59+00:00","value":{"partners":{"actual":3,"annual_target":10,"ytd_target":10},"sponsors":{"actual":1,"annual_target":5,"ytd_target":5},"supporters":{"actual":55,"annual_target":34,"ytd_target":34},"startups":{"actual":7,"annual_target":6,"ytd_target":6},"nodes":{"actual":9,"annual_target":20,"ytd_target":20},"affiliates":{"actual":0}}}'
     http_version: '1.1'
-  recorded_at: Tue, 02 Jun 2015 12:21:51 GMT
+  recorded_at: Fri, 05 Jun 2015 12:25:39 GMT
+- request:
+    method: get
+    uri: https://metrics.<SOUNDCLOUD_USERNAME>.org/metrics/current-year-network-size/2015-12-31T23:59:59+00:00
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx/1.1.19
+      content-type:
+      - application/json;charset=utf-8
+      date:
+      - Fri, 05 Jun 2015 12:25:43 GMT
+      x-content-type-options:
+      - nosniff
+      connection:
+      - close
+      content-length:
+      - '184'
+    body:
+      encoding: US-ASCII
+      string: ! '{"_id":"5571948aef922c014b000db2","name":"current-year-network-size","time":"2015-06-05T12:22:34+00:00","value":{"startups":{"actual":5},"nodes":{"actual":5},"members":{"actual":147}}}'
+    http_version: '1.1'
+  recorded_at: Fri, 05 Jun 2015 12:25:40 GMT
 - request:
     method: get
     uri: https://metrics.<SOUNDCLOUD_USERNAME>.org/metrics/cumulative-network-size
@@ -50,7 +81,7 @@ http_interactions:
       content-type:
       - application/json;charset=utf-8
       date:
-      - Tue, 02 Jun 2015 12:21:55 GMT
+      - Fri, 05 Jun 2015 12:25:44 GMT
       x-content-type-options:
       - nosniff
       connection:
@@ -59,7 +90,7 @@ http_interactions:
       - '114'
     body:
       encoding: US-ASCII
-      string: ! '{"_id":"556d90f6ef922c16fc0313e8","name":"cumulative-network-size","time":"2015-06-02T11:18:12+00:00","value":258}'
+      string: ! '{"_id":"5571948aef922c014b000db3","name":"cumulative-network-size","time":"2015-06-05T12:22:34+00:00","value":308}'
     http_version: '1.1'
-  recorded_at: Tue, 02 Jun 2015 12:21:52 GMT
+  recorded_at: Fri, 05 Jun 2015 12:25:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/libs/company_dashboard_spec.rb
+++ b/spec/libs/company_dashboard_spec.rb
@@ -279,7 +279,11 @@ describe CompanyDashboard do
       "ytd_target" => 75
     }
 
-    CompanyDashboard.network_size.should == 258
+    CompanyDashboard.network_size(2015).should == {
+      "actual" => 157,
+    }
+
+    CompanyDashboard.network_size.should == 308
   end
 
   it "should get network size for just one level", :vcr do


### PR DESCRIPTION
According to the 2015 network size tooltip, we should show new members
for 2015 on the 2015 performance dashboard, rather than a cumulative
figure.