### PR TITLE
Switch to use WEBrick

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-dashing:  bundle exec dashing start -p 3000
+web: bundle exec rackup -p $PORT -E $RACK_ENV -s webrick


### PR DESCRIPTION
The docs suggest it’s normal for numbers to go missing from widgets.
From https://github.com/Shopify/dashing/wiki/Dashing-Workshop#le-part-4-job-creation:

> Note: Chrome is sometimes weird, and it's possible that your browser
> isn't showing the number anymore in the widget. If that's the case
> load dashing in a brand new tab to clear the cache.

It seems WEBrick doesn’t suffer from this problem.
https://github.com/Shopify/dashing/issues/235#issuecomment-27761708